### PR TITLE
feat: add VPC loader that can load COPC files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ libs/CesiumUnminified
 /pointclouds/morro_bay_converted
 /pointclouds/helimap_epalinges
 pointclouds/F
+
+/examples-ignore/*
+!/examples-ignore/README.txt

--- a/examples-ignore/README.txt
+++ b/examples-ignore/README.txt
@@ -1,0 +1,1 @@
+In this directory, you can place examples with large binary files. These won't be checked into Git.

--- a/examples/vpc-lion.html
+++ b/examples/vpc-lion.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="description" content="">
+	<meta name="author" content="">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<title>Potree Viewer</title>
+
+	<link rel="stylesheet" type="text/css" href="../build/potree/potree.css">
+	<link rel="stylesheet" type="text/css" href="../libs/jquery-ui/jquery-ui.min.css">
+	<link rel="stylesheet" type="text/css" href="../libs/openlayers3/ol.css">
+	<link rel="stylesheet" type="text/css" href="../libs/spectrum/spectrum.css">
+	<link rel="stylesheet" type="text/css" href="../libs/jstree/themes/mixed/style.css">
+</head>
+
+<body>
+	<script src="../libs/jquery/jquery-3.1.1.min.js"></script>
+	<script src="../libs/spectrum/spectrum.js"></script>
+	<script src="../libs/jquery-ui/jquery-ui.min.js"></script>
+	<script src="../libs/other/BinaryHeap.js"></script>
+	<script src="../libs/tween/tween.min.js"></script>
+	<script src="../libs/d3/d3.js"></script>
+	<script src="../libs/proj4/proj4.js"></script>
+	<script src="../libs/openlayers3/ol.js"></script>
+	<script src="../libs/i18next/i18next.js"></script>
+	<script src="../libs/jstree/jstree.js"></script>
+	<script src="../libs/copc/index.js"></script>
+	<script src="../build/potree/potree.js"></script>
+	<script src="../libs/plasio/js/laslaz.js"></script>
+
+	<!-- INCLUDE ADDITIONAL DEPENDENCIES HERE -->
+	<!-- INCLUDE SETTINGS HERE -->
+
+	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
+		<div id="potree_render_area" style="background-image: url('../build/potree/resources/images/background.jpg');"></div>
+		<div id="potree_sidebar_container"> </div>
+	</div>
+
+	<script type="module">
+
+		import * as THREE from "../libs/three.js/build/three.module.js";
+			window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
+	
+			viewer.setEDLEnabled(true);
+			viewer.setFOV(60);
+			viewer.setPointBudget(2_000_000);
+			viewer.loadSettingsFromURL();
+	
+			viewer.setDescription("Loading VPC format");
+	
+			viewer.loadGUI(() => {
+				viewer.setLanguage('en');
+				$("#menu_appearance").next().show();
+			});
+	
+			var path = "../pointclouds/vpc/lion_takanawa.vpc";
+			var name = "name";
+	
+			var getQueryParam = function(name) {
+				name = name.replace(/[\[\]]/g, "\\$&");
+				var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+					results = regex.exec(window.location.href);
+				if (!results || !results[2]) return null;
+				return decodeURIComponent(results[2].replace(/\+/g, " "));
+			}
+	
+			var r = getQueryParam('r');
+			if (r) {
+				name = r;
+				var http = 'http';
+				if (r.substr(0, http.length) == http) path = name;
+				else path = "../pointclouds/" + name + "/ept.json";
+			}
+	
+			var c = getQueryParam('c');
+			Potree.loadPointCloud(path, name, function(e){
+				for (const pointcloud of e.pointcloud) {
+					viewer.scene.addPointCloud(pointcloud);
+
+					let material = pointcloud.material;
+					material.size = 1;
+					material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
+					if (c) material.activeAttributeName = c;
+		
+					viewer.fitToScreen(0.5);
+				}
+			});
+
+			// TODO properly integrate this? Or leave it out?
+			function changeAttribute(name) {
+				for (const pointcloud of viewer.scene.pointclouds) {
+					pointcloud.material.activeAttributeName = name;
+				}
+			}
+
+			const attributeNames = ['rgba', 'intensity', 'intensity gradient', 'classification', 'gps-time', 'returnNumber', 'number of returns', 'return number', 'elevation', 'color', 'source id', 'matcap', 'indices', 'level of detail', 'composite'];
+			const attributesListElement = document.createElement('div');
+			for (const attributeName of attributeNames) {
+				const attributeElement = document.createElement('div');
+				attributeElement.innerText = attributeName;
+				attributeElement.style.color = 'white';
+				attributeElement.addEventListener('click', () => changeAttribute(attributeName));
+				attributesListElement.insertAdjacentElement('beforeend', attributeElement)
+			}
+
+			const sidebar = document.getElementById("potree_sidebar_container");
+			// timeout found by experiment
+			setTimeout(() => sidebar.insertAdjacentElement('beforeend', attributesListElement), 1000);
+		</script>
+  </body>
+</html>

--- a/pointclouds/vpc/lion_takanawa.vpc
+++ b/pointclouds/vpc/lion_takanawa.vpc
@@ -1,0 +1,223 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "lion_takanawa.copc",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -4.985,
+              1.039,
+              -3.445
+            ],
+            [
+              -4.985,
+              6.724,
+              -3.445
+            ],
+            [
+              -0.789,
+              6.724,
+              1.124
+            ],
+            [
+              -0.789,
+              1.039,
+              1.124
+            ],
+            [
+              -4.985,
+              1.039,
+              -3.445
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        -4.985,
+        1.039,
+        -3.445,
+        -0.789,
+        6.724,
+        1.124
+      ],
+      "properties": {
+        "datetime": "2023-11-28T00:00:00Z",
+        "pc:count": 341989,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Synthetic",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "KeyPoint",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Withheld",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Overlap",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "ScanChannel",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Red",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "Green",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "Blue",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "OriginId",
+            "size": 4,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          -4.985,
+          1.039,
+          -3.445,
+          -0.789,
+          6.724,
+          1.124
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                -4.985,
+                1.039,
+                -3.445
+              ],
+              [
+                -4.985,
+                6.724,
+                -3.445
+              ],
+              [
+                -0.789,
+                6.724,
+                1.124
+              ],
+              [
+                -0.789,
+                1.039,
+                1.124
+              ],
+              [
+                -4.985,
+                1.039,
+                -3.445
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": ""
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "../pointclouds/lion_takanawa.copc.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    }
+  ]
+}
+

--- a/src/loader/VpcLoader.js
+++ b/src/loader/VpcLoader.js
@@ -1,0 +1,40 @@
+import {CopcLoader} from './EptLoader';
+
+export class VpcLoader {
+	static async load(file, callback) {
+		const response = await fetch(file)
+		if(!response.ok) {
+			console.error(`Failed to load file form ${file}`);
+			callback(null);
+			return;
+		}
+
+		const json = await response.json();
+
+		const geometries = [];
+		const urls = extractHrefs(json);
+		const callbackGeom = g => geometries.push(g);
+		for (const url of urls) {
+			const urlLowerCase = url.toLowerCase();
+			// TODO: we need to support more file formats
+			if (urlLowerCase.endsWith('.copc.laz')) {
+				await CopcLoader.load(url, callbackGeom);
+			} else {
+				console.warn(`Format not supported: ${url}`);
+			}
+		}
+
+		callback(geometries);
+	}
+}
+
+function extractHrefs(json) {
+	const result = [];
+
+	for (const feature of json.features) {
+		const url = feature.assets.data.href;
+		result.push(url);
+	}
+
+	return result;
+}


### PR DESCRIPTION
## VPC loader

This PR implements a [VPC](https://github.com/PDAL/wrench/blob/main/vpc-spec.md) loader for Potree. **Note:** it can only load COPC files currently.

This loader loads all referenced files separately. After loading, it adjusts the min and max heigth of all pointclouds, to get rid of border effects when looking at the elevations.

This PR contains an example in the `examples` directory, namely `vpc-lion.html`. This example loads a VPC file containing one reference to the `pointclouds/lion_takanawa.copc.laz` file, which is also used in `examples/copc.html`. This example also contains a code snippet that allows you to change the active attribute type for all pointclouds at once. This might need better integration or it might have to be removed, but can be used for larger examples consisting of multiple files.

Todos:

- Check if more metadata from the VPC files can be used.
- Call the appropriate loaders for all file formats the VPC file might reference.
- Check for more possible border effects.
- Have a discussion with the Potree maintainers on how to handle the `.vpc` extension, as it is also used by `PointCloudArena4D` for so-called [Veesus Point Cloud](https://www.veesus.com/vpc-creator/) files.
- Better error handling: what if some of the referenced files generate errors (they might not exist, they might be broken, etc.) and others do work?